### PR TITLE
Prevent Next from baking environment variables during build

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -39,6 +39,7 @@
                 "name-initials": "^0.1.3",
                 "next": "^14.2.28",
                 "next-auth": "^4.24.7",
+                "next-runtime-env": "^3.3.0",
                 "next-themes": "^0.3.0",
                 "react": "^18",
                 "react-day-picker": "^8.10.1",
@@ -4766,6 +4767,20 @@
                 "nodemailer": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/next-runtime-env": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/next-runtime-env/-/next-runtime-env-3.3.0.tgz",
+            "integrity": "sha512-JgKVnog9mNbjbjH9csVpMnz2tB2cT5sLF+7O47i6Ze/s/GoiKdV7dHhJHk1gwXpo6h5qPj5PTzryldtSjvrHuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "next": "^14",
+                "react": "^18"
+            },
+            "peerDependencies": {
+                "next": "^14",
+                "react": "^18"
             }
         },
         "node_modules/next-themes": {

--- a/app/package.json
+++ b/app/package.json
@@ -40,6 +40,7 @@
         "name-initials": "^0.1.3",
         "next": "^14.2.28",
         "next-auth": "^4.24.7",
+        "next-runtime-env": "^3.3.0",
         "next-themes": "^0.3.0",
         "react": "^18",
         "react-day-picker": "^8.10.1",

--- a/app/src/app/api/auth/[...nextauth]/route.ts
+++ b/app/src/app/api/auth/[...nextauth]/route.ts
@@ -9,7 +9,7 @@ const authOptions: AuthOptions = {
     providers: [
         GoogleProvider({
             clientId: env("NEXT_PUBLIC_GOOGLE_CLIENT_ID")!,
-            clientSecret: env("NEXT_PUBLIC_GOOGLE_CLIENT_SECRET")!,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
             authorization: {
                 params: {
                     prompt: "consent",

--- a/app/src/app/api/auth/[...nextauth]/route.ts
+++ b/app/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,6 @@
 import NextAuth, { AuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
+import { env } from "next-runtime-env";
 
 const authOptions: AuthOptions = {
     pages: {
@@ -7,8 +8,8 @@ const authOptions: AuthOptions = {
     },
     providers: [
         GoogleProvider({
-            clientId: process.env.GOOGLE_CLIENT_ID!,
-            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+            clientId: env("NEXT_PUBLIC_GOOGLE_CLIENT_ID")!,
+            clientSecret: env("NEXT_PUBLIC_GOOGLE_CLIENT_SECRET")!,
             authorization: {
                 params: {
                     prompt: "consent",

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/components/ui/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { SessionProvider } from "next-auth/react";
 import { AnonymousSessionProvider } from "@/components/anonymous-session/anonymous-session";
+import { PublicEnvScript } from "next-runtime-env";
 
 const fontSans = FontSans({
     subsets: ["latin"],
@@ -20,6 +21,9 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="en">
+            <head>
+                <PublicEnvScript />
+            </head>
             <body
                 className={cn(
                     "min-h-screen bg-background font-sans antialiased",

--- a/app/src/components/google/sheets-export-flow.tsx
+++ b/app/src/components/google/sheets-export-flow.tsx
@@ -30,6 +30,7 @@ import { TimeslotColumn } from "../timeslot-picker/timeslot-day-column";
 import { isScopeGranted } from "@/lib/google-oauth2";
 import { GoogleSignInButton } from "./google-sign-in-button";
 import { usePathname, useSearchParams } from "next/navigation";
+import { env } from "next-runtime-env";
 
 type SheetState =
     | {
@@ -134,8 +135,8 @@ export function ExportToSheetsFlow({
         closeDialogs(); // shouldn't happen, but just in case since they mutually break each other
         disable();
         openPicker({
-            clientId: process.env.GOOGLE_CLIENT_ID!,
-            developerKey: process.env.GOOGLE_PICKER_DEVELOPER_KEY!,
+            clientId: env("NEXT_PUBLIC_GOOGLE_CLIENT_ID")!,
+            developerKey: env("NEXT_PUBLIC_GOOGLE_PICKER_DEVELOPER_KEY")!,
             viewId: "SPREADSHEETS",
             token, // already have the token
             callbackFunction: (data) => {


### PR DESCRIPTION
Prevent Next from baking environment variables during the build process, and instead fetch them at run-time